### PR TITLE
Fix Layer Utilities and BatchNorm running stats

### DIFF
--- a/Source/Torcher/Private/BPUtils/TorcherLayerUtilities.cpp
+++ b/Source/Torcher/Private/BPUtils/TorcherLayerUtilities.cpp
@@ -8,9 +8,10 @@
 UObject* UTorcherLayerUtilities::CreateLayer(const UClass* Class, ETorcherTensorDeviceType TensorDeviceType, const float Gain, const float Confidence)
 {
 	check(Class && Class->ImplementsInterface(UITorcherLayer::StaticClass()));
-	auto* const TorcherLayerObject = NewObject<UObject>(GetTransientPackage(), Class);
-	auto* const TorcherLayer = CastChecked<IITorcherLayer>(TorcherLayerObject);
+       auto* const TorcherLayerObject = NewObject<UObject>(GetTransientPackage(), Class);
+       auto* const TorcherLayer = CastChecked<IITorcherLayer>(TorcherLayerObject);
 
-	TorcherLayer->InitializeLayerParams(Gain, Confidence);
-	return TorcherLayerObject;
+       TorcherLayer->SetLayerDeviceType(TensorDeviceType);
+       TorcherLayer->InitializeLayerParams(Gain, Confidence);
+       return TorcherLayerObject;
 }

--- a/Source/Torcher/Private/Layers/Normalization/TorcherLayerBatchNorm1D.cpp
+++ b/Source/Torcher/Private/Layers/Normalization/TorcherLayerBatchNorm1D.cpp
@@ -75,9 +75,13 @@ bool UTorcherLayerBatchNorm1D::Forward(const TScriptInterface<ITorcherTensorBase
 	// Update the buffers
 	if (TorcherLayerBatchNorm1DOptions.bIsTraining)
 	{
-		torch::NoGradGuard NoGrad;
-		RunningMean->SetData((1 - TorcherLayerBatchNorm1DOptions.Momentum) * (*RunningMean->GetData() + TorcherLayerBatchNorm1DOptions.Momentum + *XMean));
-		RunningVariance->SetData((1 - TorcherLayerBatchNorm1DOptions.Momentum) * (*RunningVariance->GetData() + TorcherLayerBatchNorm1DOptions.Momentum + *XVar));
+                torch::NoGradGuard NoGrad;
+                RunningMean->SetData(
+                        (1 - TorcherLayerBatchNorm1DOptions.Momentum) * (*RunningMean->GetData()) +
+                        TorcherLayerBatchNorm1DOptions.Momentum * (*XMean));
+                RunningVariance->SetData(
+                        (1 - TorcherLayerBatchNorm1DOptions.Momentum) * (*RunningVariance->GetData()) +
+                        TorcherLayerBatchNorm1DOptions.Momentum * (*XVar));
 	}
 
 	auto* const TensorObject = NewObject<UObject>(GetTransientPackage(), UTorcherTensorFloat::StaticClass());


### PR DESCRIPTION
## Summary
- ensure new layers set device type when created
- correct running mean/variance update formula in BatchNorm layer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f2afe35c83329201b67f59e878a0